### PR TITLE
Change partition structure to support non-secureboot builds

### DIFF
--- a/layers/meta-testdistro/recipes-bsp/tegra-binaries/custom-flash-layout/jetson-tx2-cboot/flash_jetson-tx2-cboot_custom.xml
+++ b/layers/meta-testdistro/recipes-bsp/tegra-binaries/custom-flash-layout/jetson-tx2-cboot/flash_jetson-tx2-cboot_custom.xml
@@ -492,25 +492,7 @@
             <percent_reserved> 0 </percent_reserved>
             <align_boundary> 4096 </align_boundary>
         </partition>
-        <partition name="DATA" type="data">
-            <allocation_policy> sequential </allocation_policy>
-            <filesystem_type> basic </filesystem_type>
-            <size> 4294967296 </size>
-            <file_system_attribute> 0 </file_system_attribute>
-            <allocation_attribute> 0x8 </allocation_attribute>
-	    <filename> DATAFILE </filename>
-            <percent_reserved> 0 </percent_reserved>
-        </partition>
-        <partition name="INSTALLER" type="data">
-            <allocation_policy> sequential </allocation_policy>
-            <filesystem_type> basic </filesystem_type>
-            <size> 314572800 </size>
-            <file_system_attribute> 0 </file_system_attribute>
-            <allocation_attribute> 0x8 </allocation_attribute>
-	    <filename> APPFILE </filename>
-            <percent_reserved> 0 </percent_reserved>
-        </partition>
-        <partition name="unused" type="data">
+        <partition name="UDA" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 18432 </size>


### PR DESCRIPTION
This change in partition structure should get past tegraflash failure.

NOTE: This is a hack. Do not merge.